### PR TITLE
Support pallet

### DIFF
--- a/support/Cargo.toml
+++ b/support/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "gamedao-protocol-support"
+version = "1.0.1-dev"
+authors = ["zero.io","gamedao.co"]
+edition = "2018"
+license = "GPL-3.0-or-later"
+description = ""
+repository = "https://github.com/gamedaoco/gamedao-protocol"
+
+
+[dependencies]
+serde = { version = "1.0.124", optional = true }
+codec = { package = "parity-scale-codec", version = "2.3.1", default-features = false }
+scale-info = { version = "1.0", default-features = false, features = ["derive"] }
+frame-support = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.13", default-features = false }
+sp-std = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.13", default-features = false }
+
+[features]
+default = ["std"]
+std = [
+	"codec/std",
+	"serde/std",
+	"scale-info/std",
+	"frame-support/std",
+    "sp-std/std",
+]

--- a/support/src/lib.rs
+++ b/support/src/lib.rs
@@ -42,10 +42,10 @@ pub enum ControlState {
 }
 
 pub trait ControlPalletStorage<AccountId, Hash> {
-    fn body_controller(org: Hash) -> AccountId;
-    fn body_treasury(org: Hash) -> AccountId;
-    fn body_member_state(hash: Hash, account_id: AccountId) -> ControlMemberState;
-    fn body_state(hash: Hash) -> ControlState;
+    fn body_controller(org: &Hash) -> AccountId;
+    fn body_treasury(org: &Hash) -> AccountId;
+    fn body_member_state(hash: &Hash, account_id: &AccountId) -> ControlMemberState;
+    fn body_state(hash: &Hash) -> ControlState;
 }
 
 pub trait FlowPalletStorage<Hash, Balance> {

--- a/support/src/lib.rs
+++ b/support/src/lib.rs
@@ -1,0 +1,56 @@
+#![cfg_attr(not(feature = "std"), no_std)]
+use frame_support::codec::{Decode, Encode};
+use scale_info::TypeInfo;
+use sp_std::fmt::Debug;
+
+// TODO: discussion: where to store enums
+
+#[derive(Encode, Decode, Clone, PartialEq, Eq, PartialOrd, Ord, TypeInfo, Debug)]
+#[repr(u8)]
+pub enum FlowState {
+    Init = 0,
+    Active = 1,
+    Paused = 2,
+    Success = 3,
+    Failed = 4,
+    Locked = 5,
+}
+
+impl Default for FlowState {
+    fn default() -> Self {
+        Self::Init
+    }
+}
+
+#[derive(Encode, Decode, PartialEq, Clone, Eq, PartialOrd, Ord, TypeInfo, Debug)]
+#[repr(u8)]
+pub enum ControlMemberState {
+    Inactive = 0, // eg inactive after threshold period
+    Active = 1,
+    Pending = 2,  // application voting pending
+    Kicked = 3,
+    Banned = 4,
+    Exited = 5,
+}
+
+#[derive(Encode, Decode, PartialEq, Clone, Eq, PartialOrd, Ord, TypeInfo, Debug)]
+#[repr(u8)]
+pub enum ControlState {
+    Inactive = 0,
+    Active = 1,
+    Locked = 2,
+}
+
+pub trait ControlPalletStorage<AccountId, Hash> {
+    fn body_controller(org: Hash) -> AccountId;
+    fn body_treasury(org: Hash) -> AccountId;
+    fn body_member_state(hash: Hash, account_id: AccountId) -> ControlMemberState;
+    fn body_state(hash: Hash) -> ControlState;
+}
+
+pub trait FlowPalletStorage<Hash, Balance> {
+    fn campaign_balance(hash: &Hash) -> Balance;
+    fn campaign_state(hash: &Hash) -> FlowState;
+    fn campaign_contributors_count(hash: &Hash) -> u64;
+    fn campaign_org(hash: &Hash) -> Hash;
+}


### PR DESCRIPTION
**What was done:** added a new pallet, "gamedao-protocol-support".

**Goal:** store traits for gamedao-protocol pallets and some common enums and structures.

**Discussion:** right now, some of the enums are stored on the pallet level, and others were moved here, it seems not the best solution to me, but I couldn't find a better one yet.
