### PR TITLE
Create treasury for organization

### DIFF
--- a/control/Cargo.toml
+++ b/control/Cargo.toml
@@ -23,7 +23,7 @@ scale-info = { version = "1.0", default-features = false, features = ["derive"] 
 sp-core = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.13" }
 sp-runtime = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.13" }
 sp-std = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.13" }
-sp-storage = {  default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.13" }
+sp-storage = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.13" }
 
 frame-support = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.13" }
 frame-system = {  default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.13" }

--- a/control/src/mock.rs
+++ b/control/src/mock.rs
@@ -132,8 +132,7 @@ frame_support::parameter_types! {
 	pub const MaxCreationsPerBlock: u32 = 2;
 	pub const ProtocolTokenId: u32 = PROTOCOL_TOKEN_ID;
 	pub const PaymentTokenId: CurrencyId = PAYMENT_TOKEN_ID;
-	pub const CreationFee: Balance = 1 * DOLLARS;
-	pub const GameDAOTreasury: AccountId = TREASURY;
+	pub const InitialDeposit: Balance = 1 * DOLLARS;
 }
 impl pallet_control::Config for Test {
 	type Balance = Balance;
@@ -145,7 +144,6 @@ impl pallet_control::Config for Test {
 	type Randomness = TestRandomness<Self>;
 
 	// type GameDAOAdminOrigin: EnsureOrigin<Self::Origin>;
-	type GameDAOTreasury = GameDAOTreasury;
 
 	type ForceOrigin = frame_system::EnsureRoot<Self::AccountId>;
 
@@ -154,7 +152,7 @@ impl pallet_control::Config for Test {
 	type MaxCreationsPerBlock = MaxCreationsPerBlock;
 	type ProtocolTokenId = ProtocolTokenId;
 	type PaymentTokenId = PaymentTokenId;
-	type CreationFee = CreationFee;
+	type InitialDeposit = InitialDeposit;
 }
 
 pub fn new_test_ext() -> sp_io::TestExternalities {

--- a/control/src/tests.rs
+++ b/control/src/tests.rs
@@ -1,17 +1,17 @@
 #![cfg(test)]
 
-use super::*;
 use frame_support::{assert_noop, assert_ok};
+use super::*;
 use mock::*;
 
 #[test]
 fn control_create_campaign_success() {
 	new_test_ext().execute_with(|| {
+		System::set_block_number(3);
 		// create a DAO with account #5.
 		assert_ok!(Control::create_org(
 			Origin::signed(ALICE),
 			BOB,
-			TREASURY,
 			vec![12, 56],
 			vec![11, 111],
 			Default::default(),
@@ -25,6 +25,19 @@ fn control_create_campaign_success() {
 
 		// check that there are now 1 Control in storage
 		assert_eq!(Nonce::<Test>::get(), 1);
+		let created_org_id = OrgByNonce::<Test>::get(0).unwrap();
+		let treasury = OrgTreasury::<Test>::get(created_org_id);
+		System::assert_has_event(
+			mock::Event::Control(
+				crate::Event::OrgCreated {
+					sender_id: ALICE,
+					org_id: created_org_id,
+					treasury_id: treasury,
+					created_at: System::block_number(),
+					realm_index: 0
+				}
+			)
+		);
 
 		// // check that account #5 is creator
 		// let creator_hash = <OrgByHash<Test>>::get(0);


### PR DESCRIPTION
* Change `create_org` extrinsic signature to not accept manually created `treasury` argument
* Create treasury account address during extrinsic execution
* Change fee transfer receiver from GameDAO treasury to the newly created treasury
* Drop some extra validations for unused token balances