### PR TITLE
Scheduling and Campaign settlement

### DIFF
--- a/flow/src/lib.rs
+++ b/flow/src/lib.rs
@@ -345,8 +345,8 @@ pub mod pallet {
 		EndTooEarly,
 		/// Campaign expiry has be lower than the block number limit
 		EndTooLate,
-		/// Max contributions per block exceeded
-		ContributionsPerBlockExceeded,
+		/// Max campaigns per block exceeded
+		CampaignsPerBlockExceeded,
 		/// Name too long
 		NameTooLong,
 		/// Name too short
@@ -475,11 +475,10 @@ pub mod pallet {
 			// for collision
 
 			// check contribution limit per block
-			let contributions = CampaignsByBlock::<T>::get(expiry);
+			let camapaigns = CampaignsByBlock::<T>::get(expiry);
 			ensure!(
-				// TODO: fix this
-				(contributions.len() as u32) < T::MaxCampaignsPerBlock::get(),
-				Error::<T>::ContributionsPerBlockExceeded
+				(camapaigns.len() as u32) < T::MaxCampaignsPerBlock::get(),
+				Error::<T>::CampaignsPerBlockExceeded
 			);
 
 			let campaign = Campaign {

--- a/flow/src/lib.rs
+++ b/flow/src/lib.rs
@@ -55,13 +55,16 @@ mod tests;
 use frame_support::{
 	codec::Encode,
 	dispatch::DispatchResult,
-	traits::{Get, Randomness, UnixTime},
+	traits::{Get, Randomness, UnixTime, BalanceStatus},
 	transactional,
+	weights::Weight
 };
 
 use scale_info::TypeInfo;
-use sp_runtime::{traits::AtLeast32BitUnsigned, Permill};
+use sp_runtime::{traits::{AtLeast32BitUnsigned}, Permill};
 use sp_std::vec::Vec;
+
+use sp_std::convert::TryFrom;
 
 use codec::HasCompact;
 use gamedao_traits::{ControlTrait, FlowTrait};
@@ -130,6 +133,8 @@ pub mod pallet {
 		type MaxCampaignsPerBlock: Get<u32>;
 		#[pallet::constant]
 		type MaxContributionsPerBlock: Get<u32>;
+		#[pallet::constant]
+		type MaxContributorsProcessing: Get<u32>;
 
 		#[pallet::constant]
 		type MinCampaignDuration: Get<Self::BlockNumber>;
@@ -195,6 +200,13 @@ pub mod pallet {
 	#[pallet::storage]
 	pub(super) type CampaignsIndex<T: Config> = StorageMap<_, Blake2_128Concat, T::Hash, u64, ValueQuery>;
 
+	/// Number of contributors processed
+	// TODO: check default 0
+	#[pallet::storage]
+	pub(super) type ContributorsFinalized<T: Config> = StorageMap<_, Blake2_128Concat, T::Hash, u32, ValueQuery, GetDefault>;
+	#[pallet::storage]
+	pub(super) type ContributorsReverted<T: Config> = StorageMap<_, Blake2_128Concat, T::Hash, u32, ValueQuery, GetDefault>;
+	
 	// caller owned campaigns -> my campaigns
 	#[pallet::storage]
 	pub(super) type CampaignsOwnedArray<T: Config> = StorageMap<_, Blake2_128Concat, T::Hash, T::Hash, ValueQuery>;
@@ -282,6 +294,18 @@ pub mod pallet {
 			block_number: T::BlockNumber,
 			success: bool,
 		},
+		CampaignReverting {
+			campaign_id: T::Hash,
+			campaign_balance: T::Balance,
+			block_number: T::BlockNumber,
+			success: bool,
+		},
+		CampaignFinalising {
+			campaign_id: T::Hash,
+			campaign_balance: T::Balance,
+			block_number: T::BlockNumber,
+			success: bool,
+		},
 		CampaignUpdated {
 			campaign_id: T::Hash,
 			state: FlowState,
@@ -364,145 +388,18 @@ pub mod pallet {
 	}
 
 	#[pallet::hooks]
-	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {
-		/// Block finalization
-		fn on_finalize(block_number: BlockNumberFor<T>) {
-			// which campaigns end in this block
-			let campaign_hashes = CampaignsByBlock::<T>::get(block_number);
+	impl<T: Config> Hooks<T::BlockNumber> for Pallet<T> {
 
-			// iterate over campaigns ending in this block
-			for campaign_id in &campaign_hashes {
-				// TODO: Reduce complexity of N^2 with unknown amount of contributors.
-				// Priority - after NFT Uniques.
-				// 1. Save all campaigns to be finalized in the current block into a stack
-				// 2. Finalize N campaigns from the stack
-				// 3. If error - save campaign into a stack (to be reversed)
-				// 4. Reverse N campaigns from the stack
+        fn on_initialize(block_number: T::BlockNumber) -> Weight {
+			let mut processed: u32 = 0;
+			Self::process_campaigns(&block_number, FlowState::Finalizing, &mut processed)
+			.saturating_add(
+				Self::process_campaigns(&block_number, FlowState::Reverting, &mut processed)
+			)
+        }
 
-				// get campaign struct
-				let campaign = Campaigns::<T>::get(campaign_id);
-				let campaign_balance = CampaignBalance::<T>::get(campaign_id);
-				let org = CampaignOrg::<T>::get(&campaign_id);
-				let org_treasury = T::Control::org_treasury_account(&org);
-
-				// check for cap reached
-				if campaign_balance >= campaign.cap {
-					// get campaign owner
-					// should be controller --- test?
-					let _owner = CampaignOwner::<T>::get(campaign_id);
-
-					match _owner {
-						Some(owner) => {
-							// get all contributors
-							let contributors = CampaignContributors::<T>::get(campaign_id);
-							let mut transaction_complete = true;
-
-							// 1 iterate over contributors
-							// 2 unreserve contribution
-							// 3 transfer contribution to campaign treasury
-							'inner: for contributor in &contributors {
-								// if contributor == campaign owner, skip
-								if contributor == &owner {
-									continue;
-								}
-
-								// get amount from contributor
-								let contributor_balance =
-									CampaignContribution::<T>::get((*campaign_id, contributor.clone()));
-
-								// unreserve the amount in contributor balance
-								T::Currency::unreserve(
-									T::PaymentTokenId::get(),
-									&contributor,
-									contributor_balance.clone(),
-								);
-
-								// transfer from contributor
-								let transfer_amount = T::Currency::transfer(
-									T::PaymentTokenId::get(),
-									&contributor,
-									&org_treasury,
-									contributor_balance.clone(),
-								);
-
-								// success?
-								match transfer_amount {
-									Err(_e) => {
-										transaction_complete = false;
-										break 'inner;
-									}
-									Ok(_v) => {}
-								}
-							}
-
-							// If all transactions are settled
-							// 1. reserve campaign balance
-							// 2. unreserve and send the commission to operator treasury
-							if transaction_complete {
-								// reserve campaign volume
-								let _reserve_campaign_amount = T::Currency::reserve(
-									T::PaymentTokenId::get(),
-									&org_treasury,
-									campaign_balance.clone(),
-								);
-
-								let fee = T::CampaignFee::get();
-								let commission = fee.mul_floor(campaign_balance.clone());
-								T::Currency::unreserve(T::PaymentTokenId::get(), &org_treasury, commission.clone());
-
-								let _transfer_commission = T::Currency::transfer(
-									T::PaymentTokenId::get(),
-									&org_treasury,
-									&T::GameDAOTreasury::get(),
-									commission,
-								);
-
-								// TODO: TransferError?
-								// match transfer_commission {
-								// 	Err(_e) => {   }, //(Error::<T>::TransferError)
-								// 	Ok(_v) => {}
-								// }
-
-								Self::set_state(campaign.id.clone(), FlowState::Success);
-
-								// finalized event
-								Self::deposit_event(Event::CampaignFinalized {
-									campaign_id: *campaign_id,
-									campaign_balance,
-									block_number,
-									success: true,
-								});
-							}
-						}
-						None => continue,
-					}
-
-				// campaign cap not reached
-				} else {
-					// campaign failed, revert all contributions
-
-					let contributors = CampaignContributors::<T>::get(campaign_id);
-					for account in contributors {
-						let contribution = CampaignContribution::<T>::get((*campaign_id, account.clone()));
-						T::Currency::unreserve(T::PaymentTokenId::get(), &account, contribution);
-					}
-
-					// update campaign state to failed
-					Self::set_state(campaign.id, FlowState::Failed);
-
-					// unreserve DEPOSIT
-
-					T::Currency::unreserve(T::ProtocolTokenId::get(), &org_treasury, campaign.deposit);
-
-					// failed event
-					Self::deposit_event(Event::CampaignFailed {
-						campaign_id: *campaign_id,
-						campaign_balance,
-						block_number,
-						success: false,
-					});
-				}
-			}
+		fn on_finalize(block_number: T::BlockNumber) {
+			Self::schedule_campaign_settlements(block_number)
 		}
 	}
 
@@ -583,6 +480,7 @@ pub mod pallet {
 			// check contribution limit per block
 			let contributions = CampaignsByBlock::<T>::get(expiry);
 			ensure!(
+				// TODO: fix this
 				(contributions.len() as u32) < T::MaxCampaignsPerBlock::get(),
 				Error::<T>::ContributionsPerBlockExceeded
 			);
@@ -836,6 +734,182 @@ impl<T: Config> Pallet<T> {
 		Nonce::<T>::put(nonce.wrapping_add(1));
 		nonce
 	}
+
+	fn schedule_campaign_settlements(block_number: T::BlockNumber) {
+		// which campaigns end in this block
+		let campaign_ids = CampaignsByBlock::<T>::get(block_number);
+
+		// iterate over campaigns ending in this block
+		for campaign_id in &campaign_ids {
+			let campaign = Campaigns::<T>::get(campaign_id);
+			let campaign_balance = CampaignBalance::<T>::get(campaign_id);
+			// check for cap reached
+			if campaign_balance >= campaign.cap {
+				Self::set_state(campaign.id, FlowState::Finalizing);
+
+				Self::deposit_event(Event::CampaignFinalising {
+					campaign_id: *campaign_id,
+					campaign_balance,
+					block_number,
+					success: false,
+				});
+
+			// campaign cap not reached
+			} else {
+				Self::set_state(campaign.id, FlowState::Reverting);
+
+				Self::deposit_event(Event::CampaignReverting {
+					campaign_id: *campaign_id,
+					campaign_balance,
+					block_number,
+					success: false,
+				});
+			}
+		}
+	}
+
+	fn process_campaigns(block_number: &T::BlockNumber, state: FlowState, processed: &mut u32) -> Weight {
+		let campaign_ids = CampaignsByState::<T>::get(&state);
+		let total_weight: Weight = 0;
+		for campaign_id in campaign_ids {
+			let campaign = Campaigns::<T>::get(campaign_id);
+			let campaign_balance = CampaignBalance::<T>::get(campaign_id);
+			let org = CampaignOrg::<T>::get(&campaign_id);
+			let org_treasury = T::Control::org_treasury_account(&org);
+			let contributors = CampaignContributors::<T>::get(campaign_id);
+
+			if state == FlowState::Finalizing {
+				if let Some(owner) = CampaignOwner::<T>::get(campaign.id) {
+					total_weight.saturating_add(
+						Self::finalize_campaign(&block_number, processed, &campaign, &campaign_balance, &org, &org_treasury, &contributors, &owner)
+					);
+				} else {
+					// TODO: If no campaign owner, what should be done?
+				}
+			} else if state == FlowState::Reverting {
+				total_weight.saturating_add(
+					Self::revert_campaign(&block_number, processed, &campaign, &campaign_balance, &org, &org_treasury, &contributors)
+				);
+			}
+		}
+		total_weight
+	}
+
+	fn finalize_campaign(
+		block_number: &T::BlockNumber, processed: &mut u32,
+		campaign: &Campaign<T::Hash, T::AccountId, T::Balance, T::BlockNumber, Moment>,
+		campaign_balance: &T::Balance, org: &T::Hash, org_treasury: &T::AccountId,
+		contributors: &Vec<T::AccountId>, owner: &T::AccountId
+	) -> Weight {
+		let contributors = CampaignContributors::<T>::get(campaign.id);
+		let processed_offset = ContributorsReverted::<T>::get(campaign.id);
+		let offset: usize = usize::try_from(processed_offset).unwrap();
+		for contributor in &contributors[offset..] {
+			if contributor == owner {
+				continue;
+			}
+			let contributor_balance = CampaignContribution::<T>::get((campaign.id, contributor));
+			
+			// Unreserve, transfer free balance from contributor to org treasury
+			let transfer_amount = T::Currency::repatriate_reserved(
+				T::PaymentTokenId::get(),
+				&contributor,
+				&org_treasury,
+				contributor_balance.clone(),
+				BalanceStatus::Free
+			);
+
+			match transfer_amount {
+				Err(_) => {
+					// TODO: Update CampaignContributors -> for proper revert_campaign processing
+					// TODO: Update CampaignBalance -> still possible to have < campaign.cap
+					// TODO: Probably create reverse function for "fn create_contribution" -> "fn remove_contribution"
+				},
+				Ok(_) => { }
+			}
+
+			*processed += 1;
+			if *processed >= T::MaxContributorsProcessing::get() {
+				ContributorsFinalized::<T>::insert(campaign.id, processed_offset + *processed);
+				// TODO: return T::WeightInfo::finalize_campaign(processed)
+				return 1 as Weight
+			}
+		}
+
+		if *campaign_balance < campaign.cap {
+			Self::set_state(campaign.id, FlowState::Reverting);
+			// TODO: return T::WeightInfo::finalize_campaign(processed)
+			return 1 as Weight
+		}
+
+		// reserve campaign volume
+		let _reserve_campaign_amount = T::Currency::reserve(
+			T::PaymentTokenId::get(),
+			&org_treasury,
+			campaign_balance.clone(),
+		);
+
+		let fee = T::CampaignFee::get();
+		let commission = fee.mul_floor(campaign_balance.clone());
+		// TODO: CampaignBalance substract comission
+
+		let _transfer_commission = T::Currency::repatriate_reserved(
+			T::PaymentTokenId::get(),
+			&org_treasury,
+			&T::GameDAOTreasury::get(),
+			commission,
+			BalanceStatus::Free
+		);
+
+		Self::set_state(campaign.id, FlowState::Success);
+
+		Self::deposit_event(Event::CampaignFinalized {
+			campaign_id: campaign.id,
+			campaign_balance: *campaign_balance,
+			block_number: *block_number,
+			success: true,
+		});
+
+		// TODO: return T::WeightInfo::finalize_campaign(processed)
+		1 as Weight
+	}
+
+	fn revert_campaign(
+		block_number: &T::BlockNumber, processed: &mut u32,
+		campaign: &Campaign<T::Hash, T::AccountId, T::Balance, T::BlockNumber, Moment>,
+		campaign_balance: &T::Balance, org: &T::Hash, org_treasury: &T::AccountId,
+		contributors: &Vec<T::AccountId>
+	) -> Weight {
+		let processed_offset = ContributorsReverted::<T>::get(campaign.id);
+		let offset: usize = usize::try_from(processed_offset).unwrap();
+		for account in &contributors[offset..] {
+			let contribution = CampaignContribution::<T>::get((campaign.id, account.clone()));
+			T::Currency::unreserve(T::PaymentTokenId::get(), &account, contribution);
+
+			*processed += 1;
+			if *processed >= T::MaxContributorsProcessing::get() {
+				ContributorsReverted::<T>::insert(campaign.id, processed_offset + *processed);
+
+				// TODO: return T::WeightInfo::revert_campaign(processed)
+				return 1 as Weight
+			}
+		}
+
+		Self::set_state(campaign.id, FlowState::Failed);
+
+		T::Currency::unreserve(T::ProtocolTokenId::get(), &org_treasury, campaign.deposit);
+
+		Self::deposit_event(Event::CampaignFailed {
+			campaign_id: campaign.id,
+			campaign_balance: *campaign_balance,
+			block_number: *block_number,
+			success: false,
+		});
+		
+		// TODO: return T::WeightInfo::revert_campaign(processed)
+		1 as Weight
+	}
+
 }
 
 impl<T: Config> FlowTrait<T::AccountId, T::Balance, T::Hash> for Pallet<T> {

--- a/flow/src/lib.rs
+++ b/flow/src/lib.rs
@@ -297,13 +297,11 @@ pub mod pallet {
 			campaign_id: T::Hash,
 			campaign_balance: T::Balance,
 			block_number: T::BlockNumber,
-			success: bool,
 		},
 		CampaignFinalising {
 			campaign_id: T::Hash,
 			campaign_balance: T::Balance,
 			block_number: T::BlockNumber,
-			success: bool,
 		},
 		CampaignUpdated {
 			campaign_id: T::Hash,
@@ -748,7 +746,6 @@ impl<T: Config> Pallet<T> {
 					campaign_id: *campaign_id,
 					campaign_balance,
 					block_number,
-					success: false,
 				});
 
 			// Campaign cap not reached: Reverting
@@ -759,7 +756,6 @@ impl<T: Config> Pallet<T> {
 					campaign_id: *campaign_id,
 					campaign_balance,
 					block_number,
-					success: false,
 				});
 			}
 		}

--- a/flow/src/mock.rs
+++ b/flow/src/mock.rs
@@ -35,11 +35,22 @@ pub const DAYS: BlockNumber = HOURS * 24;
 pub const PROTOCOL_TOKEN_ID: CurrencyId = 1;
 pub const PAYMENT_TOKEN_ID: CurrencyId = 2;
 
-// Accounts:
-pub const ALICE: AccountId = 1;
-pub const BOB: AccountId = 2;
-pub const BOGDANA: AccountId = 3;
-pub const GAMEDAO_TREASURY: AccountId = 5;
+// Contributors:
+pub const ACC_1: AccountId = 1;
+pub const ACC_2: AccountId = 2;
+pub const ACC_3: AccountId = 3;
+pub const ACC_4: AccountId = 4;
+pub const ACC_5: AccountId = 5;
+pub const ACC_6: AccountId = 6;
+pub const ACC_7: AccountId = 7;
+pub const ACC_8: AccountId = 8;
+pub const ACC_9: AccountId = 9;
+pub const ACC_10: AccountId = 10;
+pub const ALICE: AccountId = 11;
+// Org creator:
+pub const BOB: AccountId = 12;
+
+pub const GAMEDAO_TREASURY: AccountId = 13;
 
 mod gamedao_flow {
 	pub use super::super::*;
@@ -161,6 +172,7 @@ parameter_types! {
 	pub const MaxCampaignsPerAddress: u32 = 3;
 	pub const MaxCampaignsPerBlock: u32 = 1;
 	pub const MaxContributionsPerBlock: u32 = 3;
+	pub const MaxContributorsProcessing: u32 = 4;
 	pub const MinCampaignDuration: BlockNumber = 1 * DAYS;
 	pub const MaxCampaignDuration: BlockNumber = 100 * DAYS;
 	pub const MinCreatorDeposit: Balance = 1 * DOLLARS;
@@ -184,6 +196,7 @@ impl Config for Test {
 	type Control = Control;
 	type GameDAOAdminOrigin = EnsureRoot<Self::AccountId>;
 	type GameDAOTreasury = GameDAOTreasury;
+	type MaxContributorsProcessing = MaxContributorsProcessing;
 	type MinNameLength = MinNameLength;
 	type MaxNameLength = MaxNameLength;
 	type MaxCampaignsPerAddress = MaxCampaignsPerAddress;
@@ -216,12 +229,23 @@ pub fn new_test_ext() -> sp_io::TestExternalities {
 	let mut t = frame_system::GenesisConfig::default().build_storage::<Test>().unwrap();
 	orml_tokens::GenesisConfig::<Test> {
 		balances: vec![
-			(ALICE, PROTOCOL_TOKEN_ID, 100 * DOLLARS),
-			(ALICE, PAYMENT_TOKEN_ID, 100 * DOLLARS),
+			// BOB org creator
 			(BOB, PROTOCOL_TOKEN_ID, 100 * DOLLARS),
 			(BOB, PAYMENT_TOKEN_ID, 100 * DOLLARS),
-			(BOGDANA, PROTOCOL_TOKEN_ID, 100 * DOLLARS),
-			(BOGDANA, PAYMENT_TOKEN_ID, 100 * DOLLARS),
+			
+			// Contributors
+			(ALICE, PAYMENT_TOKEN_ID, 100 * DOLLARS),
+			(ACC_1, PAYMENT_TOKEN_ID, 100 * DOLLARS),
+			(ACC_2, PAYMENT_TOKEN_ID, 100 * DOLLARS),
+			(ACC_3, PAYMENT_TOKEN_ID, 100 * DOLLARS),
+			(ACC_4, PAYMENT_TOKEN_ID, 100 * DOLLARS),
+			(ACC_5, PAYMENT_TOKEN_ID, 100 * DOLLARS),
+			(ACC_6, PAYMENT_TOKEN_ID, 100 * DOLLARS),
+			(ACC_7, PAYMENT_TOKEN_ID, 100 * DOLLARS),
+			(ACC_8, PAYMENT_TOKEN_ID, 100 * DOLLARS),
+			(ACC_9, PAYMENT_TOKEN_ID, 100 * DOLLARS),
+			(ACC_10, PAYMENT_TOKEN_ID, 100 * DOLLARS),
+
 			(GAMEDAO_TREASURY, PROTOCOL_TOKEN_ID, 0),
 			(GAMEDAO_TREASURY, PAYMENT_TOKEN_ID, 0),
 		],

--- a/flow/src/tests.rs
+++ b/flow/src/tests.rs
@@ -359,18 +359,8 @@ fn flow_on_finalize_campaign_succeess() {
 		let nonce = Nonce::<Test>::get().encode();
 		let campaign_id: H256 = <Test as Config>::Randomness::random(&nonce).0;
 		assert_ok!(Flow::create_campaign(
-			Origin::signed(BOB),
-			org,
-			BOB,
-			vec![1, 2],
-			target,
-			deposit,
-			expiry,
-			FlowProtocol::Raise,
-			FlowGovernance::No,
-			vec![1, 2],
-			vec![],
-			vec![]
+			Origin::signed(BOB), org, BOB, vec![1, 2], target, deposit, expiry,
+			FlowProtocol::Raise, FlowGovernance::No, vec![1, 2], vec![], vec![]
 		));
 
 		let total_contributors: u128 = 10;
@@ -390,6 +380,12 @@ fn flow_on_finalize_campaign_succeess() {
 		// --------- Block 0 (expiry): Schedule settlements ---------
 		System::set_block_number(expiry);
 		Flow::on_finalize(expiry);
+
+		System::assert_has_event(Event::Flow(crate::Event::CampaignFinalising {
+			campaign_id,
+			campaign_balance: CampaignBalance::<Test>::get(campaign_id),
+			block_number: expiry,
+		}));
 
 		// Ensure that campaign was scheduled to be finalized
 		assert_eq!(CampaignsByState::<Test>::get(&FlowState::Finalizing), vec![campaign_id]);
@@ -478,18 +474,8 @@ fn flow_on_finalize_campaign_failed() {
 		let nonce = Nonce::<Test>::get().encode();
 		let campaign_id: H256 = <Test as Config>::Randomness::random(&nonce).0;
 		assert_ok!(Flow::create_campaign(
-			Origin::signed(BOB),
-			org,
-			BOB,
-			vec![1, 2],
-			target,
-			deposit,
-			expiry,
-			FlowProtocol::Raise,
-			FlowGovernance::No,
-			vec![1, 2],
-			vec![],
-			vec![]
+			Origin::signed(BOB), org, BOB, vec![1, 2], target, deposit, expiry,
+			FlowProtocol::Raise, FlowGovernance::No, vec![1, 2], vec![], vec![]
 		));
 
 		let total_contributors: u128 = 10;
@@ -509,6 +495,12 @@ fn flow_on_finalize_campaign_failed() {
 		// --------- Block 0 (expiry): Schedule settlements ---------
 		System::set_block_number(expiry);
 		Flow::on_finalize(expiry);
+
+		System::assert_has_event(Event::Flow(crate::Event::CampaignReverting {
+			campaign_id,
+			campaign_balance: CampaignBalance::<Test>::get(campaign_id),
+			block_number: expiry,
+		}));
 
 		// Ensure that campaign was scheduled to be reverted
 		assert_eq!(CampaignsByState::<Test>::get(&FlowState::Reverting), vec![campaign_id]);

--- a/flow/src/tests.rs
+++ b/flow/src/tests.rs
@@ -127,8 +127,8 @@ fn flow_create_errors() {
 			),
 			Error::<Test>::EndTooLate
 		);
-		// Check contribution limit per block
-		// Error: ContributionsPerBlockExceeded
+		// Check campaigns limit per block
+		// Error: CampaignsPerBlockExceeded
 		CampaignsByBlock::<Test>::mutate(current_block + 1, |campaigns| campaigns.push(H256::random()));
 		assert_noop!(
 			Flow::create_campaign(
@@ -136,7 +136,7 @@ fn flow_create_errors() {
 				current_block + 1, FlowProtocol::Raise, FlowGovernance::No,
 				vec![1, 2], vec![], vec![]
 			),
-			Error::<Test>::ContributionsPerBlockExceeded
+			Error::<Test>::CampaignsPerBlockExceeded
 		);
 	});
 }

--- a/flow/src/tests.rs
+++ b/flow/src/tests.rs
@@ -10,27 +10,19 @@ use sp_core::H256;
 
 use gamedao_control::{AccessModel, FeeModel, OrgType};
 
-fn create_org_treasury() -> (H256, AccountId) {
+fn create_org_treasury() -> (H256, AccountId, Balance) {
 	let nonce = Control::nonce().encode();
 	assert_ok!(Control::create_org(
-		Origin::signed(BOB),
-		BOB,
-		vec![1, 2],
-		vec![1, 2],
-		OrgType::default(),
-		AccessModel::default(),
-		FeeModel::default(),
-		0,
-		0,
-		0,
-		0,
-        1 * DOLLARS
+		Origin::signed(BOB), BOB, vec![1, 2], vec![1, 2],
+		OrgType::default(), AccessModel::default(), FeeModel::default(),
+		0, 0, 0, 0, 1 * DOLLARS
 	));
     let org_id = <Test as gamedao_control::Config>::Randomness::random(&nonce).0;
     let treasury_id = Control::org_treasury_account(&org_id);
-    let _ = Tokens::set_balance(RawOrigin::Root.into(), treasury_id, PROTOCOL_TOKEN_ID, 100 * DOLLARS, 0);
+	let tbalance = 30 * DOLLARS;
+    let _ = Tokens::set_balance(RawOrigin::Root.into(), treasury_id, PROTOCOL_TOKEN_ID, tbalance, 0);
 
-    (org_id, treasury_id)
+    (org_id, treasury_id, tbalance)
 }
 
 impl Campaign<Hash, AccountId, Balance, BlockNumber, Moment> {
@@ -57,7 +49,7 @@ impl Campaign<Hash, AccountId, Balance, BlockNumber, Moment> {
 #[test]
 fn flow_create_errors() {
 	new_test_ext().execute_with(|| {
-		let (org, _) = create_org_treasury();
+		let (org, _, _) = create_org_treasury();
 		let current_block = 3;
 		System::set_block_number(current_block);
 
@@ -66,18 +58,8 @@ fn flow_create_errors() {
 		let not_creator = ALICE;
 		assert_noop!(
 			Flow::create_campaign(
-				Origin::signed(not_creator),
-				org,
-				not_creator,
-				vec![1, 2],
-				0,
-				0,
-				0,
-				FlowProtocol::Raise,
-				FlowGovernance::No,
-				vec![],
-				vec![],
-				vec![]
+				Origin::signed(not_creator), org, not_creator, vec![1, 2], 0, 0, 0,
+				FlowProtocol::Raise, FlowGovernance::No, vec![], vec![], vec![]
 			),
 			Error::<Test>::AuthorizationError
 		);
@@ -86,18 +68,9 @@ fn flow_create_errors() {
 		let deposit_more_than_treasury = 1000 * DOLLARS;
 		assert_noop!(
 			Flow::create_campaign(
-				Origin::signed(BOB),
-				org,
-				BOB,
-				vec![1, 2],
-				0,
-				deposit_more_than_treasury,
-				0,
-				FlowProtocol::Raise,
-				FlowGovernance::No,
-				vec![],
-				vec![],
-				vec![]
+				Origin::signed(BOB), org, BOB, vec![1, 2], 0,
+				deposit_more_than_treasury, 0,
+				FlowProtocol::Raise, FlowGovernance::No, vec![], vec![], vec![]
 			),
 			Error::<Test>::TreasuryBalanceTooLow
 		);
@@ -107,18 +80,9 @@ fn flow_create_errors() {
 		let deposit_more_than_target = 20 * DOLLARS;
 		assert_noop!(
 			Flow::create_campaign(
-				Origin::signed(BOB),
-				org,
-				BOB,
-				vec![1, 2],
-				target,
-				deposit_more_than_target,
-				0,
-				FlowProtocol::Raise,
-				FlowGovernance::No,
-				vec![],
-				vec![],
-				vec![]
+				Origin::signed(BOB), org, BOB, vec![1, 2],
+				target, deposit_more_than_target, 0,
+				FlowProtocol::Raise, FlowGovernance::No, vec![], vec![], vec![]
 			),
 			Error::<Test>::DepositTooHigh
 		);
@@ -127,18 +91,8 @@ fn flow_create_errors() {
 		let short_name = vec![1];
 		assert_noop!(
 			Flow::create_campaign(
-				Origin::signed(BOB),
-				org,
-				BOB,
-				short_name,
-				20 * DOLLARS,
-				10 * DOLLARS,
-				0,
-				FlowProtocol::Raise,
-				FlowGovernance::No,
-				vec![],
-				vec![],
-				vec![]
+				Origin::signed(BOB), org, BOB, short_name, 20 * DOLLARS, 10 * DOLLARS, 0,
+				FlowProtocol::Raise, FlowGovernance::No, vec![], vec![], vec![]
 			),
 			Error::<Test>::NameTooShort
 		);
@@ -146,18 +100,8 @@ fn flow_create_errors() {
 		let long_name = vec![1, 2, 3, 4, 5];
 		assert_noop!(
 			Flow::create_campaign(
-				Origin::signed(BOB),
-				org,
-				BOB,
-				long_name,
-				20 * DOLLARS,
-				10 * DOLLARS,
-				0,
-				FlowProtocol::Raise,
-				FlowGovernance::No,
-				vec![],
-				vec![],
-				vec![]
+				Origin::signed(BOB), org, BOB, long_name, 20 * DOLLARS, 10 * DOLLARS, 0,
+				FlowProtocol::Raise, FlowGovernance::No, vec![], vec![], vec![]
 			),
 			Error::<Test>::NameTooLong
 		);
@@ -166,18 +110,9 @@ fn flow_create_errors() {
 		let expiration_block = current_block - 1;
 		assert_noop!(
 			Flow::create_campaign(
-				Origin::signed(BOB),
-				org,
-				BOB,
-				vec![1, 2],
-				20 * DOLLARS,
-				10 * DOLLARS,
-				expiration_block,
-				FlowProtocol::Raise,
-				FlowGovernance::No,
-				vec![],
-				vec![],
-				vec![]
+				Origin::signed(BOB), org, BOB, vec![1, 2], 20 * DOLLARS, 10 * DOLLARS,
+				expiration_block, FlowProtocol::Raise, FlowGovernance::No,
+				vec![], vec![],vec![]
 			),
 			Error::<Test>::EndTooEarly
 		);
@@ -186,18 +121,9 @@ fn flow_create_errors() {
 		let expiration_block = MaxCampaignDuration::get() + current_block + 1;
 		assert_noop!(
 			Flow::create_campaign(
-				Origin::signed(BOB),
-				org,
-				BOB,
-				vec![1, 2],
-				20 * DOLLARS,
-				10 * DOLLARS,
-				expiration_block,
-				FlowProtocol::Raise,
-				FlowGovernance::No,
-				vec![],
-				vec![],
-				vec![]
+				Origin::signed(BOB), org, BOB, vec![1, 2],
+				20 * DOLLARS, 10 * DOLLARS, expiration_block,
+				FlowProtocol::Raise, FlowGovernance::No, vec![], vec![], vec![]
 			),
 			Error::<Test>::EndTooLate
 		);
@@ -206,18 +132,9 @@ fn flow_create_errors() {
 		CampaignsByBlock::<Test>::mutate(current_block + 1, |campaigns| campaigns.push(H256::random()));
 		assert_noop!(
 			Flow::create_campaign(
-				Origin::signed(BOB),
-				org,
-				BOB,
-				vec![1, 2],
-				20 * DOLLARS,
-				10 * DOLLARS,
-				current_block + 1,
-				FlowProtocol::Raise,
-				FlowGovernance::No,
-				vec![1, 2],
-				vec![],
-				vec![]
+				Origin::signed(BOB), org, BOB, vec![1, 2], 20 * DOLLARS, 10 * DOLLARS,
+				current_block + 1, FlowProtocol::Raise, FlowGovernance::No,
+				vec![1, 2], vec![], vec![]
 			),
 			Error::<Test>::ContributionsPerBlockExceeded
 		);
@@ -227,7 +144,7 @@ fn flow_create_errors() {
 #[test]
 fn flow_create_success() {
 	new_test_ext().execute_with(|| {
-		let (org, treasury) = create_org_treasury();
+		let (org, treasury, _) = create_org_treasury();
 		let current_block = 3;
 		System::set_block_number(current_block);
 
@@ -239,18 +156,8 @@ fn flow_create_success() {
 		let name = vec![1, 2];
 
 		assert_ok!(Flow::create_campaign(
-			Origin::signed(BOB),
-			org,
-			BOB,
-			name.clone(),
-			target,
-			deposit,
-			expiry,
-			FlowProtocol::Raise,
-			FlowGovernance::No,
-			vec![1, 2],
-			vec![],
-			vec![]
+			Origin::signed(BOB), org, BOB, name.clone(), target, deposit, expiry,
+			FlowProtocol::Raise, FlowGovernance::No, vec![1, 2], vec![], vec![]
 		));
 
 		assert_eq!(Campaigns::<Test>::get(id).id, id);
@@ -269,30 +176,16 @@ fn flow_create_success() {
 		assert_eq!(CampaignsByState::<Test>::get(FlowState::Active), vec![id]);
 		assert_eq!(CampaignState::<Test>::get(id), FlowState::Active);
 
-		// Events
-		assert_eq!(
-			System::events(),
-			vec![
-				EventRecord {
-					phase: Phase::Initialization,
-					event: Event::Tokens(orml_tokens::Event::Reserved(PROTOCOL_TOKEN_ID, treasury, deposit)),
-					topics: vec![],
-				},
-				EventRecord {
-					phase: Phase::Initialization,
-					event: Event::Flow(crate::Event::CampaignCreated {
-						campaign_id: id,
-						creator: BOB,
-						admin: BOB,
-						target,
-						deposit,
-						expiry,
-						name
-					}),
-					topics: vec![],
-				},
-			]
-		);
+		System::assert_has_event(Event::Flow(crate::Event::CampaignCreated {
+			campaign_id: id,
+			creator: BOB,
+			admin: BOB,
+			target,
+			deposit,
+			expiry,
+			name
+		}));
+
 	});
 }
 
@@ -441,41 +334,26 @@ fn flow_contribute_success() {
 		assert_eq!(CampaignContribution::<Test>::get((campaign_id, ALICE)), contribution);
 		assert_eq!(CampaignBalance::<Test>::get(campaign_id), contribution);
 
-		// Events
-		assert_eq!(
-			System::events(),
-			vec![
-				EventRecord {
-					phase: Phase::Initialization,
-					event: Event::Tokens(orml_tokens::Event::Reserved(PAYMENT_TOKEN_ID, ALICE, contribution)),
-					topics: vec![],
-				},
-				EventRecord {
-					phase: Phase::Initialization,
-					event: Event::Flow(crate::Event::CampaignContributed {
-						campaign_id,
-						sender: ALICE,
-						contribution,
-						block_number: current_block
-					}),
-					topics: vec![],
-				},
-			]
-		);
+		System::assert_has_event(Event::Flow(crate::Event::CampaignContributed {
+			campaign_id,
+			sender: ALICE,
+			contribution,
+			block_number: current_block
+		}));
 	});
 }
 
 #[test]
 fn flow_on_finalize_campaign_succeess() {
 	new_test_ext().execute_with(|| {
-		let (org, treasury) = create_org_treasury();
+		let (org, treasury, tbalance) = create_org_treasury();
 		let current_block = 3;
 		System::set_block_number(current_block);
 
 		let expiry = current_block + 1;
 		let deposit = 10 * DOLLARS;
 		let contribution = 60 * DOLLARS;
-		let target = 100 * DOLLARS;
+		let target = 500 * DOLLARS;
 
 		// Create Campaign
 		let nonce = Nonce::<Test>::get().encode();
@@ -494,116 +372,107 @@ fn flow_on_finalize_campaign_succeess() {
 			vec![],
 			vec![]
 		));
-		// Contribute (60/100)
-		assert_ok!(Flow::contribute(Origin::signed(ALICE), campaign_id, contribution));
-		// Contribute (120/100)
-		assert_ok!(Flow::contribute(Origin::signed(BOGDANA), campaign_id, contribution));
 
-		// deposit > capacity
+		let total_contributors: u128 = 10;
+		// Contribute (60/500)
+		assert_ok!(Flow::contribute(Origin::signed(ACC_1), campaign_id, contribution));
+		assert_ok!(Flow::contribute(Origin::signed(ACC_2), campaign_id, contribution));
+		assert_ok!(Flow::contribute(Origin::signed(ACC_3), campaign_id, contribution));
+		assert_ok!(Flow::contribute(Origin::signed(ACC_4), campaign_id, contribution));
+		assert_ok!(Flow::contribute(Origin::signed(ACC_5), campaign_id, contribution));
+		assert_ok!(Flow::contribute(Origin::signed(ACC_6), campaign_id, contribution));
+		assert_ok!(Flow::contribute(Origin::signed(ACC_7), campaign_id, contribution));
+		assert_ok!(Flow::contribute(Origin::signed(ACC_8), campaign_id, contribution));
+		assert_ok!(Flow::contribute(Origin::signed(ACC_9), campaign_id, contribution));
+		// Contribute (600/500)
+		assert_ok!(Flow::contribute(Origin::signed(ACC_10), campaign_id, contribution));
+
+		// --------- Block 0 (expiry): Schedule settlements ---------
 		System::set_block_number(expiry);
 		Flow::on_finalize(expiry);
 
-		let commission = <Test as Config>::CampaignFee::get().mul_floor(contribution * 2);
+		// Ensure that campaign was scheduled to be finalized
+		assert_eq!(CampaignsByState::<Test>::get(&FlowState::Finalizing), vec![campaign_id]);
+		// Ensure that campaign will be finalize in 3 blocks: 4 + 4 + 2
+		let batch_size: u128 = 4;
+		assert_eq!(MaxContributorsProcessing::get(), batch_size as u32);
 
+		// --------- Block 1: process first 4 contributors ---------
+		System::set_block_number(expiry + 1);
+		Flow::on_initialize(expiry + 1);
+
+		assert_eq!(ContributorsFinalized::<Test>::get(campaign_id), batch_size as u32);
 		assert_eq!(
 			<Test as Config>::Currency::total_balance(PAYMENT_TOKEN_ID, &treasury),
-			contribution * 2 - commission
+			batch_size * contribution
 		);
-		assert_eq!(<Test as Config>::Currency::free_balance(PAYMENT_TOKEN_ID, &treasury), 0);
 		assert_eq!(
-			<Test as Config>::Currency::free_balance(PROTOCOL_TOKEN_ID, &treasury),
-			100 * DOLLARS - deposit
+			<Test as Config>::Currency::free_balance(PAYMENT_TOKEN_ID, &treasury),
+			0
 		);
 
+		// --------- Block 2: process next 4 contributors ---------
+		System::set_block_number(expiry + 2);
+		Flow::on_initialize(expiry + 2);
+
+		assert_eq!(ContributorsFinalized::<Test>::get(campaign_id), batch_size as u32 * 2);
 		assert_eq!(
-			// Skip events from create and contribute extrinsics
-			System::events()[6..],
-			vec![
-				EventRecord {
-					phase: Phase::Initialization,
-					event: Event::Tokens(orml_tokens::Event::Unreserved(PAYMENT_TOKEN_ID, ALICE, contribution)),
-					topics: vec![],
-				},
-                EventRecord {
-					phase: Phase::Initialization,
-					event: Event::Tokens(orml_tokens::Event::Endowed(PAYMENT_TOKEN_ID, treasury, contribution)),
-					topics: vec![],
-				},
-				EventRecord {
-					phase: Phase::Initialization,
-					event: Event::Currencies(orml_currencies::Event::Transferred(
-						PAYMENT_TOKEN_ID,
-						ALICE,
-						treasury,
-						contribution
-					)),
-					topics: vec![],
-				},
-				EventRecord {
-					phase: Phase::Initialization,
-					event: Event::Tokens(orml_tokens::Event::Unreserved(PAYMENT_TOKEN_ID, BOGDANA, contribution)),
-					topics: vec![],
-				},
-				EventRecord {
-					phase: Phase::Initialization,
-					event: Event::Currencies(orml_currencies::Event::Transferred(
-						PAYMENT_TOKEN_ID,
-						BOGDANA,
-						treasury,
-						contribution
-					)),
-					topics: vec![],
-				},
-				EventRecord {
-					phase: Phase::Initialization,
-					event: Event::Tokens(orml_tokens::Event::Reserved(
-						PAYMENT_TOKEN_ID,
-						treasury,
-						contribution * 2
-					)),
-					topics: vec![],
-				},
-				EventRecord {
-					phase: Phase::Initialization,
-					event: Event::Tokens(orml_tokens::Event::Unreserved(PAYMENT_TOKEN_ID, treasury, commission)),
-					topics: vec![],
-				},
-				EventRecord {
-					phase: Phase::Initialization,
-					event: Event::Currencies(orml_currencies::Event::Transferred(
-						PAYMENT_TOKEN_ID,
-						treasury,
-						GAMEDAO_TREASURY,
-						commission
-					)),
-					topics: vec![],
-				},
-				EventRecord {
-					phase: Phase::Initialization,
-					event: Event::Flow(crate::Event::CampaignFinalized {
-						campaign_id,
-						campaign_balance: contribution * 2,
-						block_number: expiry,
-						success: true
-					}),
-					topics: vec![],
-				},
-			]
+			<Test as Config>::Currency::total_balance(PAYMENT_TOKEN_ID, &treasury),
+			2 * batch_size * contribution
 		);
+		assert_eq!(
+			<Test as Config>::Currency::free_balance(PAYMENT_TOKEN_ID, &treasury),
+			0
+		);
+
+		// --------- Block 3: process last 2 contributors and finalize Campaign ---------
+		System::set_block_number(expiry + 3);
+		Flow::on_initialize(expiry + 3);
+
+		assert_eq!(ContributorsFinalized::<Test>::get(campaign_id), total_contributors as u32);
+		let commission = <Test as Config>::CampaignFee::get().mul_floor(contribution * 10);
+		// The balance was transfered and locked in the org treasury
+		assert_eq!(
+			<Test as Config>::Currency::total_balance(PAYMENT_TOKEN_ID, &treasury),
+			total_contributors * contribution - commission
+		);
+		assert_eq!(
+			<Test as Config>::Currency::free_balance(PAYMENT_TOKEN_ID, &treasury),
+			0
+		);
+		// Initial deposit is still locked
+		assert_eq!(
+			<Test as Config>::Currency::total_balance(PROTOCOL_TOKEN_ID, &treasury),
+			tbalance
+		);
+		assert_eq!(
+			<Test as Config>::Currency::free_balance(PROTOCOL_TOKEN_ID, &treasury),
+			tbalance - deposit
+		);
+		// Ensure that campaign succeeded
+		assert_eq!(CampaignsByState::<Test>::get(&FlowState::Success), vec![campaign_id]);
+		System::assert_has_event(Event::Flow(crate::Event::CampaignFinalized {
+			campaign_id,
+			campaign_balance: CampaignBalance::<Test>::get(campaign_id),
+			block_number: expiry + 3,
+			success: true,
+		}));
+
 	});
 }
 
 #[test]
 fn flow_on_finalize_campaign_failed() {
 	new_test_ext().execute_with(|| {
-		let (org, treasury) = create_org_treasury();
+		let (org, treasury, tbalance) = create_org_treasury();
 		let current_block = 3;
 		System::set_block_number(current_block);
 
 		let expiry = current_block + 1;
 		let deposit = 10 * DOLLARS;
 		let contribution = 60 * DOLLARS;
-		let target = 100 * DOLLARS;
+		let target = 1000 * DOLLARS;
+		let init_acc_balance = 100 * DOLLARS;
 
 		// Create Campaign
 		let nonce = Nonce::<Test>::get().encode();
@@ -622,48 +491,93 @@ fn flow_on_finalize_campaign_failed() {
 			vec![],
 			vec![]
 		));
-		// Contribute (60/100)
-		assert_ok!(Flow::contribute(Origin::signed(ALICE), campaign_id, contribution));
 
-		// deposit < capacity
+		let total_contributors: u128 = 10;
+		// Contribute (60/1000)
+		assert_ok!(Flow::contribute(Origin::signed(ACC_1), campaign_id, contribution));
+		assert_ok!(Flow::contribute(Origin::signed(ACC_2), campaign_id, contribution));
+		assert_ok!(Flow::contribute(Origin::signed(ACC_3), campaign_id, contribution));
+		assert_ok!(Flow::contribute(Origin::signed(ACC_4), campaign_id, contribution));
+		assert_ok!(Flow::contribute(Origin::signed(ACC_5), campaign_id, contribution));
+		assert_ok!(Flow::contribute(Origin::signed(ACC_6), campaign_id, contribution));
+		assert_ok!(Flow::contribute(Origin::signed(ACC_7), campaign_id, contribution));
+		assert_ok!(Flow::contribute(Origin::signed(ACC_8), campaign_id, contribution));
+		assert_ok!(Flow::contribute(Origin::signed(ACC_9), campaign_id, contribution));
+		// Contribute (600/1000)
+		assert_ok!(Flow::contribute(Origin::signed(ACC_10), campaign_id, contribution));
+
+		// --------- Block 0 (expiry): Schedule settlements ---------
 		System::set_block_number(expiry);
 		Flow::on_finalize(expiry);
 
+		// Ensure that campaign was scheduled to be reverted
+		assert_eq!(CampaignsByState::<Test>::get(&FlowState::Reverting), vec![campaign_id]);
+		// Ensure that campaign will be reverted in 3 blocks: 4 + 4 + 2
+		let batch_size: u128 = 4;
+		assert_eq!(MaxContributorsProcessing::get(), batch_size as u32);
+
+		// --------- Block 1: process first 4 contributors ---------
+		System::set_block_number(expiry + 1);
+		Flow::on_initialize(expiry + 1);
+
+		assert_eq!(ContributorsReverted::<Test>::get(campaign_id), batch_size as u32);
+
+		// Account's balance from the first batch was unlocked
 		assert_eq!(
-			<Test as Config>::Currency::total_balance(PROTOCOL_TOKEN_ID, &treasury),
-			100 * DOLLARS
+			<Test as Config>::Currency::free_balance(PAYMENT_TOKEN_ID, &ACC_1),
+			init_acc_balance
+		);
+		assert_eq!(
+			<Test as Config>::Currency::free_balance(PAYMENT_TOKEN_ID, &ACC_5),
+			init_acc_balance - contribution
 		);
 
+		// --------- Block 2: process next 4 contributors ---------
+		System::set_block_number(expiry + 2);
+		Flow::on_initialize(expiry + 2);
+
+		assert_eq!(ContributorsReverted::<Test>::get(campaign_id), batch_size as u32 * 2);
+
+		// Account's balance from the second batch was unlocked
+		assert_eq!(
+			<Test as Config>::Currency::free_balance(PAYMENT_TOKEN_ID, &ACC_5),
+			init_acc_balance
+		);
+		assert_eq!(
+			<Test as Config>::Currency::free_balance(PAYMENT_TOKEN_ID, &ACC_10),
+			init_acc_balance - contribution
+		);
+
+		// --------- Block 3: process last 2 contributors and set Campaign's status to FAILED ---------
+		System::set_block_number(expiry + 3);
+		Flow::on_initialize(expiry + 3);
+
+		assert_eq!(ContributorsReverted::<Test>::get(campaign_id), total_contributors as u32);
+		assert_eq!(
+			<Test as Config>::Currency::free_balance(PAYMENT_TOKEN_ID, &ACC_10),
+			init_acc_balance
+		);
+		// Nothing transferred into the org treasury
+		assert_eq!(<Test as Config>::Currency::free_balance(PAYMENT_TOKEN_ID, &treasury), 0);
+		assert_eq!(<Test as Config>::Currency::total_balance(PAYMENT_TOKEN_ID, &treasury), 0);
+		// Initial deposit was unlocked
 		assert_eq!(
 			<Test as Config>::Currency::free_balance(PROTOCOL_TOKEN_ID, &treasury),
-			100 * DOLLARS
+			tbalance
 		);
-
 		assert_eq!(
-			// Skip events from create and contribute extrinsics
-			System::events()[4..],
-			vec![
-				EventRecord {
-					phase: Phase::Initialization,
-					event: Event::Tokens(orml_tokens::Event::Unreserved(PAYMENT_TOKEN_ID, ALICE, contribution)),
-					topics: vec![],
-				},
-				EventRecord {
-					phase: Phase::Initialization,
-					event: Event::Tokens(orml_tokens::Event::Unreserved(PROTOCOL_TOKEN_ID, treasury, deposit)),
-					topics: vec![],
-				},
-				EventRecord {
-					phase: Phase::Initialization,
-					event: Event::Flow(crate::Event::CampaignFailed {
-						campaign_id,
-						campaign_balance: contribution,
-						block_number: expiry,
-						success: false
-					}),
-					topics: vec![],
-				},
-			]
+			<Test as Config>::Currency::total_balance(PROTOCOL_TOKEN_ID, &treasury),
+			tbalance
 		);
+		// Ensure that campaign failed
+		assert_eq!(CampaignsByState::<Test>::get(&FlowState::Failed), vec![campaign_id]);
+
+		System::assert_has_event(Event::Flow(crate::Event::CampaignFailed {
+			campaign_id,
+			campaign_balance: CampaignBalance::<Test>::get(campaign_id),
+			block_number: expiry + 3,
+			success: false,
+		}));
+
 	});
 }

--- a/flow/src/types.rs
+++ b/flow/src/types.rs
@@ -26,9 +26,11 @@ pub enum FlowState {
 	Init = 0,
 	Active = 1,
 	Paused = 2,
-	Success = 3,
-	Failed = 4,
-	Locked = 5,
+	Finalizing = 3,
+	Reverting = 4,
+	Success = 5,
+	Failed = 6,
+	Locked = 7,
 }
 
 impl Default for FlowState {

--- a/signal/src/mock.rs
+++ b/signal/src/mock.rs
@@ -172,6 +172,7 @@ parameter_types! {
 	pub const MaxCampaignsPerAddress: u32 = 3;
 	pub const MaxCampaignsPerBlock: u32 = 1;
 	pub const MaxContributionsPerBlock: u32 = 3;
+	pub const MaxContributorsProcessing: u32 = 5;
 	pub const MinCampaignDuration: BlockNumber = 1 * DAYS;
 	pub const MaxCampaignDuration: BlockNumber = 100 * DAYS;
 	pub const MinCreatorDeposit: Balance = 1 * DOLLARS;
@@ -194,6 +195,7 @@ impl gamedao_flow::Config for Test {
 	type GameDAOTreasury = GameDAOTreasury;
 	type MinNameLength = MinNameLength;
 	type MaxNameLength = MaxNameLength;
+	type MaxContributorsProcessing = MaxContributorsProcessing;
 	type MaxCampaignsPerAddress = MaxCampaignsPerAddress;
 	type MaxCampaignsPerBlock = MaxCampaignsPerBlock;
 	type MaxContributionsPerBlock = MaxContributionsPerBlock;


### PR DESCRIPTION
[Figma diagram](https://www.figma.com/file/Jqy2XnQh9ZgvU518Zhp48u/Scheduling-%2B-Campaign-Settlement?node-id=0%3A1)
- Added scheduler, which is responsible for Campaign finalization.
- Updated Flow tests.

**Test scenario:**
- Set runtime: `MaxContributorsProcessing = 4`
- Extrinsic: Create a Campaign
- Extrinsic: Make 10 Contributions
- Ensure: 1st block 4 contributors were finalized
- Ensure: 2nd block 4 contributors were finalized
- Ensure: 3rd block 2 contributors were finalized, and the Campaign was finalized (FAILED or FINALIZED status)

**Do we need to handle this scenario?**
https://github.com/gamedaoco/gamedao-protocol/blob/0cec633f4869d2d43d6a97981d2fe11a86619f7d/flow/src/lib.rs#L818-L824

I've found the following reasons why it can fail:
- from_account has one or multiple BalanceLocks -> frozen balance
- from_account reserved balance was slashed
- to_account was not in DustRemovalWhitelist, and its balance < existential deposit
- to_account ArithmeticError::Overflow

Based on this, it looks like not such a possible scenario.